### PR TITLE
WIP: try to support more types

### DIFF
--- a/csvtools.nim
+++ b/csvtools.nim
@@ -113,7 +113,7 @@ proc getValue(fieldTy, row: NimNode, pos: var int): NimNode =
     result = newCall(fieldTy, newCall("string2uint", value))
     pos.inc
   elif field.hasType("DateTime"):
-    newCall("string2date", value)
+    result = newCall("string2date", value)
     pos.inc
   elif fieldTy.kind == nnkBracketExpr and fieldTy[0].eqIdent("array"):
     fieldTy[1].expectKind(nnkInfix)

--- a/csvtools.nim
+++ b/csvtools.nim
@@ -110,11 +110,13 @@ proc getValue(fieldTy, row: NimNode, pos: var int): NimNode =
     if fieldTy.eqIdent("string"):
       result = value
     elif fieldTy.hasTypeClass(bindSym"SomeSignedInt"):
-      result = newCall(fieldTy, newCall(bindSym"parseInt", value))
+      result = newCall(fieldTy, newCall("string2int", value))
     elif fieldTy.hasTypeClass(bindSym"SomeFloat"):
-      result = newCall(fieldTy, newCall(bindSym"parseFloat", value))
+      result = newCall(fieldTy, newCall("string2float", value))
     elif fieldTy.hasTypeClass(bindSym"SomeUnsignedInt"):
-      result = newCall(fieldTy, newCall(bindSym"parseUInt", value))
+      result = newCall(fieldTy, newCall("string2uint", value))
+    elif elif field.hasType("DateTime"):
+      result = newCall("string2date", value)
     else:
       error(fieldTy.lineInfo & ": Unsupported type for field")
     inc(pos)


### PR DESCRIPTION
The genPack procedure can now:
* parse uints
* support type classes e.g. ``SomeFloat``
* support arrays, tuples and distinct types
* support nesting all the above

I think I will not add support for reference types because I had problems with infinite recursion. Any ideas how to solve this are welcome. Also case objects and sequences will not be supported.